### PR TITLE
增加对M1芯片的esbuild依赖

### DIFF
--- a/compiler/parse.mjs
+++ b/compiler/parse.mjs
@@ -10,7 +10,7 @@ const parser = {
         const output = parse(input, index);
         return output instanceof ParseError ?
             output :
-            [{ type, value: output[0], id: jsxid }, output[1]];
+            [{ type, value: output[0], id: index }, output[1]];
     },
     EOF: (input, index) => {
         return index === input.length ?

--- a/compiler/parse.mjs
+++ b/compiler/parse.mjs
@@ -10,7 +10,7 @@ const parser = {
         const output = parse(input, index);
         return output instanceof ParseError ?
             output :
-            [{ type, value: output[0], id: index }, output[1]];
+            [{ type, value: output[0] }, output[1]];
     },
     EOF: (input, index) => {
         return index === input.length ?

--- a/compiler/parse.mjs
+++ b/compiler/parse.mjs
@@ -297,7 +297,7 @@ const grammar = {
 
 function parse(input) {
     let ast = grammar.main(input, 0);
-    return {ast, amount}
+    return {ast}
 }
 
 export { parse };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chalk": "^5.1.2",
     "es-module-lexer": "^1.0.3",
     "esbuild": "^0.15.10",
+    "esbuild-darwin-arm64": "^0.15.11",
     "polka": "^0.5.2",
     "sirv": "^2.0.2"
   }


### PR DESCRIPTION
增加对M1芯片的esbuild依赖，目前默认安装的是因特尔芯片的esbuild的依赖。