### PR TITLE
chore: add "engines" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "node demo/server.mjs",
     "build": "node src/build.mjs"
   },
+  "engines": {
+    "node": ">=17.5.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/yisar/asta.git"


### PR DESCRIPTION
### Description

add "engines" field to specify which versions of npm are capable of properly start program